### PR TITLE
RGB colors as fractions rather than doubles

### DIFF
--- a/Copy Swift Code.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/Copy Swift Code.sketchplugin/Contents/Sketch/script.cocoascript
@@ -29,9 +29,9 @@ function generateCode(initializer, context) {
           'let ' + varName +
           (varCount > 1 ? varCount : '') +
           ' = ' + initializer + '(' +
-          'red: ' + color.red()  + ', ' +
-          'green: ' + color.green()  + ', ' +
-          'blue: ' + color.blue()  + ', ' +
+          'red: ' +  Math.round((color.red())*255) + '/255'  + ', ' +
+          'green: ' + Math.round((color.green())*255) + '/255'  + ', ' +
+          'blue: ' + Math.round((color.blue())*255) + '/255'  + ', ' +
           'alpha: ' + color.alpha()  + ')'
         );
       }


### PR DESCRIPTION
These changes will enable plugin users to see more accurate colors, defined by fractions. 
They will also have the added benefit of creating cleaner code.
